### PR TITLE
fix: Ensure arch binaries do not overwrite each other + install handling no shortcut file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,14 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Rename binary with arch suffix
+        run: mv target/release/cosmic-app-switcher target/release/cosmic-app-switcher-x86_64-unknown-linux-gnu
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: cosmic-app-switcher-x86_64-unknown-linux-gnu
-          path: target/release/cosmic-app-switcher
+          path: target/release/cosmic-app-switcher-x86_64-unknown-linux-gnu
 
   build-aarch64:
     name: Build aarch64
@@ -67,11 +70,14 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Rename binary with arch suffix
+        run: mv target/release/cosmic-app-switcher target/release/cosmic-app-switcher-aarch64-unknown-linux-gnu
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: cosmic-app-switcher-aarch64-unknown-linux-gnu
-          path: target/release/cosmic-app-switcher
+          path: target/release/cosmic-app-switcher-aarch64-unknown-linux-gnu
 
   release:
     name: Create Release
@@ -86,21 +92,10 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Rename binaries with arch suffix
-        run: |
-          mv artifacts/cosmic-app-switcher artifacts/cosmic-app-switcher-x86_64-unknown-linux-gnu || true
-          ls artifacts/
-
-      - name: Download aarch64 artifact separately
-        uses: actions/download-artifact@v4
-        with:
-          name: cosmic-app-switcher-aarch64-unknown-linux-gnu
-          path: artifacts/aarch64
-
       - name: Prepare release assets
         run: |
-          mv artifacts/aarch64/cosmic-app-switcher artifacts/cosmic-app-switcher-aarch64-unknown-linux-gnu
           chmod +x artifacts/cosmic-app-switcher-*
+          file artifacts/cosmic-app-switcher-*
           ls -lh artifacts/
 
       - name: Create GitHub Release

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,11 @@ reinstall: uninstall install
 # Check that the COSMIC environment is compatible with this tool
 check-compat:
 	@echo "Checking compatibility..."
-	@bash scripts/find-config.sh > /dev/null && echo "  COSMIC shortcuts config: found" || echo "  COSMIC shortcuts config: NOT found"
+	@bash scripts/find-config.sh > /dev/null 2>&1; case $$? in \
+		0) echo "  COSMIC shortcuts config: found" ;; \
+		2) echo "  COSMIC shortcuts config: not created yet (run 'make enable')" ;; \
+		*) echo "  COSMIC shortcuts config: NOT found" ;; \
+	esac
 	@test -f $(INSTALL_DIR)/$(BINARY) && echo "  Binary: installed" || echo "  Binary: not installed"
 	@command -v cosmic-comp >/dev/null 2>&1 && echo "  cosmic-comp: found" || echo "  cosmic-comp: not found (is COSMIC running?)"
 	@echo "Done."

--- a/scripts/disable.sh
+++ b/scripts/disable.sh
@@ -2,7 +2,23 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONFIG=$("$SCRIPT_DIR/find-config.sh") || exit 1
+
+set +e
+CONFIG=$("$SCRIPT_DIR/find-config.sh")
+rc=$?
+set -e
+
+case "$rc" in
+    0) ;;
+    2)
+        # No config exists yet — nothing to remove.
+        echo "Already disabled."
+        exit 0
+        ;;
+    *)
+        exit "$rc"
+        ;;
+esac
 
 if ! grep -q "cosmic-app-switcher" "$CONFIG"; then
     echo "Already disabled."

--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -3,19 +3,31 @@ set -euo pipefail
 
 BINARY="$HOME/.local/bin/cosmic-app-switcher"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEFAULT_CONFIG="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
 
-CONFIG=$("$SCRIPT_DIR/find-config.sh" 2>/dev/null) || CONFIG=""
+set +e
+CONFIG=$("$SCRIPT_DIR/find-config.sh")
+rc=$?
+set -e
+
+case "$rc" in
+    0) ;;
+    2)
+        if [ ! -f "$BINARY" ]; then
+            echo "Error: binary not found at $BINARY — run 'make install' first to deploy the binary." >&2
+            exit 1
+        fi
+        mkdir -p "$(dirname "$CONFIG")"
+        printf '{\n    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' "$BINARY" "$BINARY" > "$CONFIG"
+        echo "Created $CONFIG and enabled. cosmic-comp will reload shortcuts automatically."
+        exit 0
+        ;;
+    *)
+        exit "$rc"
+        ;;
+esac
 
 if [ ! -f "$BINARY" ]; then
     echo "Warning: binary not found at $BINARY — run 'make install' first to deploy the binary."
-fi
-
-if [ -z "$CONFIG" ]; then
-    mkdir -p "$(dirname "$DEFAULT_CONFIG")"
-    printf '{\n    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' "$BINARY" "$BINARY" > "$DEFAULT_CONFIG"
-    echo "Created $DEFAULT_CONFIG and enabled. cosmic-comp will reload shortcuts automatically."
-    exit 0
 fi
 
 if grep -q "cosmic-app-switcher" "$CONFIG"; then

--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -3,15 +3,24 @@ set -euo pipefail
 
 BINARY="$HOME/.local/bin/cosmic-app-switcher"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CONFIG=$("$SCRIPT_DIR/find-config.sh") || exit 1
+DEFAULT_CONFIG="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/system_actions"
+
+CONFIG=$("$SCRIPT_DIR/find-config.sh" 2>/dev/null) || CONFIG=""
+
+if [ ! -f "$BINARY" ]; then
+    echo "Warning: binary not found at $BINARY — run 'make install' first to deploy the binary."
+fi
+
+if [ -z "$CONFIG" ]; then
+    mkdir -p "$(dirname "$DEFAULT_CONFIG")"
+    printf '{\n    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' "$BINARY" "$BINARY" > "$DEFAULT_CONFIG"
+    echo "Created $DEFAULT_CONFIG and enabled. cosmic-comp will reload shortcuts automatically."
+    exit 0
+fi
 
 if grep -q "cosmic-app-switcher" "$CONFIG"; then
     echo "Already enabled."
     exit 0
-fi
-
-if [ ! -f "$BINARY" ]; then
-    echo "Warning: binary not found at $BINARY — run 'make install' first to deploy the binary."
 fi
 
 TMPFILE=$(mktemp)

--- a/scripts/find-config.sh
+++ b/scripts/find-config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Prints the path to the COSMIC system_actions shortcuts config, or exits 1 if not found.
-# Searches all versioned directories so it works across COSMIC updates (v1, v2, ...).
+# Prints the COSMIC system_actions shortcuts config path, centralising version (v1, v2, ...) awareness.
+# Exit 0: existing config printed. Exit 2: none yet, canonical creation path printed. Exit 1: COSMIC not installed.
 
 SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts"
 
@@ -10,12 +10,16 @@ if [ ! -d "$SHORTCUTS_DIR" ]; then
     exit 1
 fi
 
-# Pick the highest versioned system_actions file present
 CONFIG=$(find "$SHORTCUTS_DIR" -name "system_actions" 2>/dev/null | sort -V | tail -1)
 
-if [ -z "$CONFIG" ]; then
-    echo "Error: No system_actions file found under $SHORTCUTS_DIR" >&2
-    exit 1
+if [ -n "$CONFIG" ]; then
+    echo "$CONFIG"
+    exit 0
 fi
 
-echo "$CONFIG"
+VERSION_DIR=$(find "$SHORTCUTS_DIR" -maxdepth 1 -type d -name 'v[0-9]*' 2>/dev/null | sort -V | tail -1)
+if [ -z "$VERSION_DIR" ]; then
+    VERSION_DIR="$SHORTCUTS_DIR/v1"
+fi
+echo "$VERSION_DIR/system_actions"
+exit 2

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -15,17 +15,26 @@ else
 fi
 
 # Shortcuts config
-CONFIG=$("$SCRIPT_DIR/find-config.sh" 2>/dev/null) || CONFIG=""
-if [ -z "$CONFIG" ]; then
-    echo "Config:    COSMIC shortcuts config not found"
-else
-    echo "Config:    $CONFIG"
-    if grep -q "cosmic-app-switcher" "$CONFIG" 2>/dev/null; then
-        echo "Shortcuts: enabled"
-    else
-        echo "Shortcuts: disabled"
-    fi
-fi
+set +e
+CONFIG=$("$SCRIPT_DIR/find-config.sh" 2>/dev/null)
+rc=$?
+set -e
+case "$rc" in
+    0)
+        echo "Config:    $CONFIG"
+        if grep -q "cosmic-app-switcher" "$CONFIG" 2>/dev/null; then
+            echo "Shortcuts: enabled"
+        else
+            echo "Shortcuts: disabled"
+        fi
+        ;;
+    2)
+        echo "Config:    none yet (run 'make enable' to create it)"
+        ;;
+    *)
+        echo "Config:    COSMIC shortcuts config not found (is COSMIC installed?)"
+        ;;
+esac
 
 # Build
 if [ -f "$(dirname "$SCRIPT_DIR")/target/release/cosmic-app-switcher" ]; then


### PR DESCRIPTION
The x86 binary that I pulled down was an arm64 build so just updated the GHA to be name specific so they dont collide. Also ran into an issue where the install.sh file was unable to handle an install on my system which had no shortcut file configured. 