### PR TITLE
Fix Steam games not appearing in switcher

### DIFF
--- a/src/icons.rs
+++ b/src/icons.rs
@@ -2,18 +2,23 @@ use freedesktop_desktop_entry::{DesktopEntry, Iter as DesktopIter};
 use std::path::PathBuf;
 
 pub fn icon_name_for(app_id: &str) -> String {
+    if app_id.is_empty() {
+        return "application-x-executable".to_string();
+    }
+
+    let home = std::env::var("HOME").unwrap_or_default();
     let search_dirs = vec![
         PathBuf::from("/usr/share/applications"),
-        PathBuf::from(format!(
-            "{}/.local/share/applications",
-            std::env::var("HOME").unwrap_or_default()
-        )),
+        PathBuf::from(format!("{home}/.local/share/applications")),
         PathBuf::from("/var/lib/flatpak/exports/share/applications"),
-        PathBuf::from(format!(
-            "{}/.local/share/flatpak/exports/share/applications",
-            std::env::var("HOME").unwrap_or_default()
-        )),
+        PathBuf::from(format!("{home}/.local/share/flatpak/exports/share/applications")),
     ];
+
+    // Steam games: always use the generic Steam icon rather than trying to resolve
+    // game-specific icons, which aren't reliably resolvable via from_name().
+    if app_id.starts_with("steam_app_") {
+        return "steam".to_string();
+    }
 
     // Direct filename match: "firefox" -> "firefox.desktop"
     for dir in &search_dirs {
@@ -22,13 +27,12 @@ pub fn icon_name_for(app_id: &str) -> String {
             let Ok(s) = std::str::from_utf8(&bytes) else { continue };
             let Ok(entry) = DesktopEntry::decode(&path, s) else { continue };
             if let Some(icon) = entry.icon() {
-                return icon.to_string();
+                return icon_name_from_field(icon);
             }
         }
     }
 
     // Scan all .desktop files for StartupWMClass match
-    // Handles apps like Chrome, Ghostty with non-standard app_ids
     for path in DesktopIter::new(search_dirs) {
         let Ok(bytes) = std::fs::read(&path) else { continue };
         let Ok(s) = std::str::from_utf8(&bytes) else { continue };
@@ -36,11 +40,26 @@ pub fn icon_name_for(app_id: &str) -> String {
         let wm_class = entry.startup_wm_class().unwrap_or_default();
         if wm_class.eq_ignore_ascii_case(app_id) {
             if let Some(icon) = entry.icon() {
-                return icon.to_string();
+                return icon_name_from_field(icon);
             }
         }
     }
 
     // Fallback: last component of reverse-DNS name
     app_id.split('.').last().unwrap_or(app_id).to_string()
+}
+
+// If the Icon= field in a .desktop file is an absolute path, extract the stem
+// (e.g. "/path/to/steam_icon_480.png" -> "steam_icon_480") so that from_name()
+// can resolve it through the XDG icon theme where Steam has already installed it.
+fn icon_name_from_field(icon: &str) -> String {
+    if icon.starts_with('/') {
+        std::path::Path::new(icon)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(icon)
+            .to_string()
+    } else {
+        icon.to_string()
+    }
 }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -78,7 +78,7 @@ fn wayland_thread_main(
     data.toplevels.sort_by_key(|t| if t.is_active { 0usize } else { 1 });
 
     let entries: Vec<ToplevelEntry> = data.toplevels.iter().enumerate()
-        .filter(|(_, t)| !t.app_id.is_empty())
+        .filter(|(_, t)| !t.app_id.is_empty() || !t.title.is_empty())
         .map(|(i, t)| ToplevelEntry {
             app_id:     t.app_id.clone(),
             title:      t.title.clone(),


### PR DESCRIPTION
## Summary

- Steam games use `steam_app_<id>` as their `app_id`, which has no matching `.desktop` file — previously they were filtered out by the `!app_id.is_empty()` check combined with having no `.desktop` entry
- Added explicit detection of `steam_app_*` app IDs to return the `steam` icon rather than failing to resolve a game-specific icon
- Added `icon_name_from_field()` helper to handle `.desktop` files where `Icon=` is an absolute path (e.g. `/path/to/icon.png`) — extracts the file stem so the XDG icon theme lookup works correctly
- Relaxed the toplevel filter in `wayland.rs` to also include entries with a non-empty title but empty `app_id`, so Steam games (which sometimes report an empty `app_id`) aren't silently dropped

## Test plan

- [ ] Launch a Steam game and confirm it appears in the Super+Tab switcher
- [ ] Confirm the Steam icon (not a blank/fallback icon) is shown for Steam games
- [ ] Confirm non-Steam apps still resolve their icons correctly
- [ ] Confirm apps with absolute-path `Icon=` fields in their `.desktop` files display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)