### PR TITLE
feat: add workspace scope filtering (all workspaces / current monitor)

### DIFF
--- a/applet/src/app.rs
+++ b/applet/src/app.rs
@@ -10,7 +10,7 @@ use cosmic::{
 };
 use cosmic::iced::platform_specific::shell::commands::popup::{destroy_popup, get_popup};
 use cosmic::cosmic_config::{ConfigGet, ConfigSet};
-use switcher_config::{Theme, APP_ID, CONFIG_VERSION};
+use switcher_config::{Theme, WorkspaceScope, APP_ID, CONFIG_VERSION};
 
 const APPLET_ID: &str = "io.github.cosmic-ext-applet-app-switcher";
 
@@ -18,6 +18,7 @@ pub struct AppletApp {
     core:                Core,
     popup:               Option<WindowId>,
     current_theme:       Theme,
+    current_scope:       WorkspaceScope,
     config_handler:      Option<cosmic::cosmic_config::Config>,
     shortcut_configured: bool,
     shortcut_error:      Option<String>,
@@ -28,6 +29,7 @@ pub enum Message {
     TogglePopup,
     PopupClosed(WindowId),
     SetTheme(Theme),
+    SetScope(WorkspaceScope),
     ToggleShortcut(bool),
 }
 
@@ -174,12 +176,17 @@ impl Application for AppletApp {
             .as_ref()
             .and_then(|c| c.get::<Theme>("theme").ok())
             .unwrap_or_default();
+        let current_scope  = config_handler
+            .as_ref()
+            .and_then(|c| c.get::<WorkspaceScope>("workspace_scope").ok())
+            .unwrap_or_default();
 
         (
             Self {
                 core,
                 popup: None,
                 current_theme,
+                current_scope,
                 config_handler,
                 shortcut_configured: shortcut_is_configured(),
                 shortcut_error: None,
@@ -223,6 +230,12 @@ impl Application for AppletApp {
                     let _ = handler.set("theme", &theme);
                 }
                 self.current_theme = theme;
+            }
+            Message::SetScope(scope) => {
+                if let Some(handler) = &self.config_handler {
+                    let _ = handler.set("workspace_scope", &scope);
+                }
+                self.current_scope = scope;
             }
             Message::ToggleShortcut(enable) => {
                 let result = if enable {
@@ -295,6 +308,31 @@ impl Application for AppletApp {
             })
             .collect();
 
+        let scope_options: Vec<Element<Message>> = WorkspaceScope::all()
+            .into_iter()
+            .map(|s| {
+                let selected = s == self.current_scope;
+                let label = s.label().to_string();
+
+                let card = container(text(label).size(12))
+                    .padding([6, 10])
+                    .style(move |_: &cosmic::Theme| ContainerStyle {
+                        border: Border {
+                            radius: 6.0.into(),
+                            width: if selected { 2.0 } else { 1.0 },
+                            color: if selected {
+                                Color::from_rgb(0.38, 0.58, 1.0)
+                            } else {
+                                Color::from_rgba(1.0, 1.0, 1.0, 0.15)
+                            },
+                        },
+                        ..Default::default()
+                    });
+
+                mouse_area(card).on_press(Message::SetScope(s)).into()
+            })
+            .collect();
+
         let shortcut_row = row![
             text("Super+Tab shortcut").size(14),
             cosmic::widget::Space::new().width(Length::Fill),
@@ -308,6 +346,9 @@ impl Application for AppletApp {
             cosmic::widget::divider::horizontal::default(),
             text("Theme").size(14),
             row(swatches).spacing(12),
+            cosmic::widget::divider::horizontal::default(),
+            text("Switch scope").size(14),
+            row(scope_options).spacing(8),
         ]
         .spacing(12)
         .padding(16)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -68,3 +68,30 @@ impl Theme {
         [v.bg[0], v.bg[1], v.bg[2]]
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum WorkspaceScope {
+    #[default]
+    AllWorkspaces,
+    CurrentWorkspace,
+    CurrentOutput,
+}
+
+impl WorkspaceScope {
+    pub fn label(&self) -> &str {
+        match self {
+            WorkspaceScope::AllWorkspaces   => "All workspaces",
+            WorkspaceScope::CurrentWorkspace => "Current workspace",
+            WorkspaceScope::CurrentOutput    => "Current monitor",
+        }
+    }
+
+    // CurrentWorkspace is intentionally excluded: cosmic-comp never sends the legacy
+    // workspace_enter/workspace_leave events this project's protocol binding relies on,
+    // so it's currently a no-op (see src/wayland.rs). Left defined for a future migration
+    // to ext_foreign_toplevel_list_v1 + ext_workspace_enter/leave, but hidden from the
+    // picker so it doesn't look like a working option that silently does nothing.
+    pub fn all() -> [WorkspaceScope; 2] {
+        [WorkspaceScope::AllWorkspaces, WorkspaceScope::CurrentOutput]
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use cosmic::cosmic_config::ConfigGet;
-use switcher_config::{Theme, APP_ID, CONFIG_VERSION};
+use switcher_config::{Theme, WorkspaceScope, APP_ID, CONFIG_VERSION};
 
 pub fn socket_path() -> std::path::PathBuf {
     let dir = std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/tmp".to_string());
@@ -30,6 +30,14 @@ fn load_theme() -> Theme {
         .unwrap_or_default()
 }
 
+fn load_scope() -> WorkspaceScope {
+    use cosmic::cosmic_config::Config;
+    Config::new(APP_ID, CONFIG_VERSION)
+        .ok()
+        .and_then(|c| c.get::<WorkspaceScope>("workspace_scope").ok())
+        .unwrap_or_default()
+}
+
 fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();
@@ -45,7 +53,8 @@ fn main() -> Result<()> {
     let _ = std::fs::remove_file(socket_path());
 
     let theme = load_theme();
-    let (toplevels, cmd_tx) = wayland::spawn_wayland_thread()?;
+    let scope = load_scope();
+    let (toplevels, cmd_tx) = wayland::spawn_wayland_thread(scope)?;
     if toplevels.is_empty() {
         return Ok(());
     }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 use anyhow::Result;
 use wayland_client::{
     Connection, Dispatch, QueueHandle, event_created_child,
-    protocol::{wl_registry, wl_seat},
+    protocol::{wl_output, wl_registry, wl_seat},
 };
 use cosmic_protocols::{
     toplevel_info::v1::client::{
@@ -13,7 +13,13 @@ use cosmic_protocols::{
     toplevel_management::v1::client::zcosmic_toplevel_manager_v1::{
         self, ZcosmicToplevelManagerV1,
     },
+    workspace::v1::client::{
+        zcosmic_workspace_group_handle_v1::{self, ZcosmicWorkspaceGroupHandleV1},
+        zcosmic_workspace_handle_v1::{self, ZcosmicWorkspaceHandleV1},
+        zcosmic_workspace_manager_v1::{self, ZcosmicWorkspaceManagerV1},
+    },
 };
+use switcher_config::WorkspaceScope;
 
 #[derive(Debug, Clone)]
 pub struct ToplevelEntry {
@@ -28,12 +34,14 @@ pub enum ActivateCommand {
     Cancel,
 }
 
-pub fn spawn_wayland_thread() -> Result<(Vec<ToplevelEntry>, mpsc::SyncSender<ActivateCommand>)> {
+pub fn spawn_wayland_thread(
+    scope: WorkspaceScope,
+) -> Result<(Vec<ToplevelEntry>, mpsc::SyncSender<ActivateCommand>)> {
     let (list_tx, list_rx) = mpsc::sync_channel(1);
     let (cmd_tx, cmd_rx)   = mpsc::sync_channel(1);
 
     std::thread::spawn(move || {
-        if let Err(e) = wayland_thread_main(list_tx, cmd_rx) {
+        if let Err(e) = wayland_thread_main(scope, list_tx, cmd_rx) {
             log::error!("wayland thread: {e}");
         }
     });
@@ -43,20 +51,31 @@ pub fn spawn_wayland_thread() -> Result<(Vec<ToplevelEntry>, mpsc::SyncSender<Ac
 }
 
 struct AppData {
-    toplevels: Vec<Toplevel>,
-    _info:     Option<ZcosmicToplevelInfoV1>,  // must stay alive to receive events
-    manager:   Option<ZcosmicToplevelManagerV1>,
-    seat:      Option<wl_seat::WlSeat>,
+    toplevels:          Vec<Toplevel>,
+    _info:              Option<ZcosmicToplevelInfoV1>,  // must stay alive to receive events
+    manager:            Option<ZcosmicToplevelManagerV1>,
+    seat:               Option<wl_seat::WlSeat>,
+    _workspace_manager: Option<ZcosmicWorkspaceManagerV1>,
+    outputs:            Vec<wl_output::WlOutput>,
+    // cosmic-comp does a one-time sync of each toplevel's output membership at handle
+    // creation time, using whatever wl_output binds the client already has — so we must
+    // not bind zcosmic_toplevel_info_v1 (which creates toplevel handles) until our own
+    // wl_output binds have been sent first. Deferred here and bound explicitly after the
+    // registry listing is fully drained, rather than reactively as its Global arrives.
+    toplevel_info_name: Option<u32>,
 }
 
 struct Toplevel {
-    handle:    ZcosmicToplevelHandleV1,
-    app_id:    String,
-    title:     String,
-    is_active: bool,
+    handle:     ZcosmicToplevelHandleV1,
+    app_id:     String,
+    title:      String,
+    is_active:  bool,
+    outputs:    Vec<wl_output::WlOutput>,
+    workspaces: Vec<ZcosmicWorkspaceHandleV1>,
 }
 
 fn wayland_thread_main(
+    scope:   WorkspaceScope,
     list_tx: mpsc::SyncSender<Vec<ToplevelEntry>>,
     cmd_rx:  mpsc::Receiver<ActivateCommand>,
 ) -> Result<()> {
@@ -65,20 +84,76 @@ fn wayland_thread_main(
     let mut queue = conn.new_event_queue();
     let qh = queue.handle();
 
-    let _registry = display.get_registry(&qh, ());
+    let registry = display.get_registry(&qh, ());
 
-    let mut data = AppData { toplevels: vec![], _info: None, manager: None, seat: None };
+    let mut data = AppData {
+        toplevels: vec![],
+        _info: None,
+        manager: None,
+        seat: None,
+        _workspace_manager: None,
+        outputs: vec![],
+        toplevel_info_name: None,
+    };
 
-    // Three roundtrips: registry → bind globals → receive all toplevel events
+    // First roundtrip: drain the full registry listing. wl_output/wl_seat/workspace-manager
+    // are bound immediately as their Globals arrive; zcosmic_toplevel_info_v1's bind is
+    // deferred (see AppData::toplevel_info_name) regardless of where in the listing it
+    // appears.
     queue.roundtrip(&mut data)?;
+
+    // Second roundtrip: force the server to fully process our wl_output bind requests
+    // before we bind toplevel_info below — otherwise toplevel handles it creates may miss
+    // their initial output_enter sync (see comment on toplevel_info_name).
     queue.roundtrip(&mut data)?;
-    queue.roundtrip(&mut data)?;
+
+    if let Some(name) = data.toplevel_info_name.take() {
+        data._info = Some(registry.bind::<ZcosmicToplevelInfoV1, _, _>(name, 1, &qh, ()));
+    }
+
+    // Extra roundtrips over the original three: workspace-group/workspace handles and
+    // toplevel handles both need time to fully cascade before we read state back out.
+    for _ in 0..5 {
+        queue.roundtrip(&mut data)?;
+    }
 
     // Sort: active window first (index 0 = current), rest in protocol order
     data.toplevels.sort_by_key(|t| if t.is_active { 0usize } else { 1 });
 
+    // Scope filtering uses the previously-focused (active) window as the reference
+    // point for "current workspace" / "current monitor" — there's no direct way to
+    // query pointer/focus location via these protocols, but the window being
+    // switched away from is a reliable proxy for both.
+    let active_outputs: Vec<wl_output::WlOutput> = data.toplevels.iter()
+        .find(|t| t.is_active)
+        .map(|t| t.outputs.clone())
+        .unwrap_or_default();
+    // Kept for the future migration this unblocks (see CurrentWorkspace arm below),
+    // but currently unread: legacy workspace_enter/workspace_leave never fire.
+    let _active_workspaces: Vec<ZcosmicWorkspaceHandleV1> = data.toplevels.iter()
+        .find(|t| t.is_active)
+        .map(|t| t.workspaces.clone())
+        .unwrap_or_default();
+
+    let in_scope = |t: &Toplevel| -> bool {
+        match scope {
+            WorkspaceScope::AllWorkspaces => true,
+            WorkspaceScope::CurrentWorkspace => {
+                // Legacy workspace_enter/workspace_leave are never sent by cosmic-comp
+                // (confirmed by reading its server source) — no membership data is
+                // available via this protocol path. No-op until a migration to
+                // ext_foreign_toplevel_list_v1 + ext_workspace_enter/leave lands.
+                true
+            }
+            WorkspaceScope::CurrentOutput => {
+                active_outputs.is_empty()
+                    || t.outputs.iter().any(|o| active_outputs.contains(o))
+            }
+        }
+    };
+
     let entries: Vec<ToplevelEntry> = data.toplevels.iter().enumerate()
-        .filter(|(_, t)| !t.app_id.is_empty() || !t.title.is_empty())
+        .filter(|(_, t)| (!t.app_id.is_empty() || !t.title.is_empty()) && (t.is_active || in_scope(t)))
         .map(|(i, t)| ToplevelEntry {
             app_id:     t.app_id.clone(),
             title:      t.title.clone(),
@@ -86,6 +161,11 @@ fn wayland_thread_main(
             handle_key: i,
         })
         .collect();
+
+    log::debug!(
+        "scope={scope:?}: {}/{} toplevels in scope (active outputs={})",
+        entries.len(), data.toplevels.len(), active_outputs.len(),
+    );
 
     list_tx.send(entries).ok();
 
@@ -120,9 +200,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
         if let wl_registry::Event::Global { name, interface, .. } = event {
             match interface.as_str() {
                 "zcosmic_toplevel_info_v1" => {
-                    data._info = Some(
-                        registry.bind::<ZcosmicToplevelInfoV1, _, _>(name, 1, qh, ())
-                    );
+                    // Binding deferred until after wl_output is bound — see
+                    // AppData::toplevel_info_name and wayland_thread_main.
+                    data.toplevel_info_name = Some(name);
                 }
                 "zcosmic_toplevel_manager_v1" => {
                     data.manager = Some(
@@ -135,6 +215,16 @@ impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
                             registry.bind::<wl_seat::WlSeat, _, _>(name, 7, qh, ())
                         );
                     }
+                }
+                "wl_output" => {
+                    data.outputs.push(
+                        registry.bind::<wl_output::WlOutput, _, _>(name, 1, qh, ())
+                    );
+                }
+                "zcosmic_workspace_manager_v1" => {
+                    data._workspace_manager = Some(
+                        registry.bind::<ZcosmicWorkspaceManagerV1, _, _>(name, 1, qh, ())
+                    );
                 }
                 _ => {}
             }
@@ -155,10 +245,12 @@ impl Dispatch<ZcosmicToplevelInfoV1, ()> for AppData {
     ) {
         if let zcosmic_toplevel_info_v1::Event::Toplevel { toplevel } = event {
             data.toplevels.push(Toplevel {
-                handle:    toplevel,
-                app_id:    String::new(),
-                title:     String::new(),
-                is_active: false,
+                handle:     toplevel,
+                app_id:     String::new(),
+                title:      String::new(),
+                is_active:  false,
+                outputs:    vec![],
+                workspaces: vec![],
             });
         }
     }
@@ -199,6 +291,22 @@ impl Dispatch<ZcosmicToplevelHandleV1, ()> for AppData {
             zcosmic_toplevel_handle_v1::Event::Closed => {
                 data.toplevels.retain(|t| &t.handle != handle);
             }
+            zcosmic_toplevel_handle_v1::Event::OutputEnter { output } => {
+                if !t.outputs.contains(&output) {
+                    t.outputs.push(output);
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputLeave { output } => {
+                t.outputs.retain(|o| o != &output);
+            }
+            zcosmic_toplevel_handle_v1::Event::WorkspaceEnter { workspace } => {
+                if !t.workspaces.contains(&workspace) {
+                    t.workspaces.push(workspace);
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::WorkspaceLeave { workspace } => {
+                t.workspaces.retain(|w| w != &workspace);
+            }
             _ => {}
         }
     }
@@ -215,4 +323,42 @@ impl Dispatch<ZcosmicToplevelManagerV1, ()> for AppData {
 impl Dispatch<wl_seat::WlSeat, ()> for AppData {
     fn event(_: &mut Self, _: &wl_seat::WlSeat, _: wl_seat::Event,
              _: &(), _: &Connection, _: &QueueHandle<Self>) {}
+}
+
+impl Dispatch<wl_output::WlOutput, ()> for AppData {
+    fn event(_: &mut Self, _: &wl_output::WlOutput, _: wl_output::Event,
+             _: &(), _: &Connection, _: &QueueHandle<Self>) {}
+}
+
+// --- Workspace hierarchy: bound only so zcosmic_toplevel_handle_v1's workspace_enter/
+// leave events have valid zcosmic_workspace_handle_v1 objects to reference. We don't
+// need names/coordinates/active-state off these — membership identity is enough to
+// compare against the currently-active toplevel's own workspace list.
+
+impl Dispatch<ZcosmicWorkspaceManagerV1, ()> for AppData {
+    fn event(_: &mut Self, _: &ZcosmicWorkspaceManagerV1,
+             _: zcosmic_workspace_manager_v1::Event, _: &(),
+             _: &Connection, _: &QueueHandle<Self>) {}
+
+    event_created_child!(AppData, ZcosmicWorkspaceManagerV1, [
+        zcosmic_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE =>
+            (ZcosmicWorkspaceGroupHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ZcosmicWorkspaceGroupHandleV1, ()> for AppData {
+    fn event(_: &mut Self, _: &ZcosmicWorkspaceGroupHandleV1,
+             _: zcosmic_workspace_group_handle_v1::Event, _: &(),
+             _: &Connection, _: &QueueHandle<Self>) {}
+
+    event_created_child!(AppData, ZcosmicWorkspaceGroupHandleV1, [
+        zcosmic_workspace_group_handle_v1::EVT_WORKSPACE_OPCODE =>
+            (ZcosmicWorkspaceHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ZcosmicWorkspaceHandleV1, ()> for AppData {
+    fn event(_: &mut Self, _: &ZcosmicWorkspaceHandleV1,
+             _: zcosmic_workspace_handle_v1::Event, _: &(),
+             _: &Connection, _: &QueueHandle<Self>) {}
 }


### PR DESCRIPTION
## Summary
- Adds a `WorkspaceScope` config option (`AllWorkspaces`, `CurrentOutput`) that filters which windows appear in the switcher, plus a picker for it in the panel applet's popup settings.
- Output-scoped filtering uses the previously-active toplevel's outputs as a proxy for "current monitor," since these protocols expose no direct pointer/focus-location query. Getting this right required binding `wl_output` before `zcosmic_toplevel_info_v1` — cosmic-comp syncs each toplevel's output membership once at handle-creation time using whatever outputs the client has already bound.
- `CurrentWorkspace` is defined but intentionally excluded from the picker: cosmic-comp never sends the legacy `workspace_enter`/`workspace_leave` events this protocol path relies on, so it would silently no-op. Left in place for a future migration to `ext_foreign_toplevel_list_v1` + `ext_workspace_enter`/`leave`.

## Test plan
- [x] `cargo build --release --workspace` clean
- [x] Live-triggered Super+Tab multiple times post-install, including after today's cosmic-comp upgrade — no crash, `AllWorkspaces` scope confirmed working via debug logs
- [x] `CurrentOutput` scoping previously verified working after fixing wl_output bind ordering (see commit message)
- [ ] Applet scope picker UI not visually re-verified in this session (built successfully; widget code unchanged from earlier verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)