### PR TITLE
fix: repair one-line installer and harden shortcut config writes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,3 +75,51 @@ There's no published table mapping cosmic-comp releases to compatible
 4. Update this project's `Cargo.toml` to match, run `cargo build`, and re-verify Super+Tab
    end-to-end (a build succeeding is not sufficient — the crash described above happens
    at runtime, not compile time).
+
+## Release checklist
+
+The version lives in `[workspace.package]` in the root `Cargo.toml`; both crates inherit it
+with `version.workspace = true`. Three things must agree or the release workflow fails:
+
+1. Bump `[workspace.package] version`.
+2. Add a matching `<release version="…" date="…">` at the top of
+   `applet/data/io.github.cosmic-ext-applet-app-switcher.metainfo.xml`. **This entry is what
+   the COSMIC Store displays** — a stale one is why the store advertised 0.1.3 long after
+   v0.1.4 shipped.
+3. Tag `vX.Y.Z` and push. `.github/workflows/release.yml` checks tag/Cargo/metainfo before
+   building and refuses to publish a mismatch.
+4. The store does **not** follow tags or `main`. It rebuilds only when a PR to
+   `pop-os/cosmic-flatpak` changes the pinned `"commit"` in
+   `app/io.github.cosmic-ext-applet-app-switcher/io.github.cosmic-ext-applet-app-switcher.json`.
+   Open that PR, regenerating the sibling `cargo-sources.json`
+   (`flatpak/generate-cargo-sources.sh`) whenever `Cargo.lock` moved.
+
+The in-repo `io.github.cosmic-ext-applet-app-switcher.json` is a local-build variant, and
+differs from the upstream one in exactly two ways — diff them before opening a PR:
+
+- `sources` uses a local `dir` instead of a pinned `git` commit, so `flatpak-builder`
+  builds the working tree.
+- it omits `base: com.system76.Cosmic.BaseApp` / `base-version: stable`. That base is not
+  published on the user-facing `cosmic` remote (only cosmic-flatpak's own build
+  environment has it), so keeping it here would break local builds. Re-add it in the PR.
+
+## Flatpak: the switcher cannot work inside the sandbox
+
+cosmic-comp gates its privileged globals on `client_not_sandboxed`
+(`src/state.rs`), which is false for any client carrying a Wayland security context —
+which Flatpak ≥1.15 always attaches. Verified empirically on 2026-08-13 by dumping
+`wl_registry` inside and outside the sandbox: the host sees 58 globals, the sandbox 36,
+and the 22 missing ones include **`zcosmic_toplevel_info_v1`, `zcosmic_toplevel_manager_v1`
+and `zwlr_layer_shell_v1`** — i.e. no window list and no overlay surface. The store build
+therefore exits silently on Super+Tab.
+
+Two further sandbox facts: `--filesystem=/usr/share/applications:ro` (and the `icons`/
+`pixmaps` equivalents) in the manifest are **silently ignored** — Flatpak reserves `/usr`,
+so the sandbox sees 0 host `.desktop` files and only the `hicolor` icon theme, breaking
+icon lookup. And nothing of ours runs at `flatpak uninstall`, so a registered shortcut
+outlives the app.
+
+The only configuration found that restores the globals is opting out of the Wayland
+sandbox entirely: `--nosocket=wayland --filesystem=xdg-run/wayland-N` plus
+`WAYLAND_DISPLAY` pointed at the host socket (verified: 58 globals inside the sandbox).
+That is a deliberate sandbox bypass and needs cosmic-flatpak maintainer buy-in.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,33 @@ permissions:
   contents: write
 
 jobs:
+  check-version:
+    name: Check version consistency
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # The tag, the crate version and the metainfo <release> are three separate places
+      # that have drifted before — the store shows the metainfo one, so a stale entry
+      # ships a release users see as an older version.
+      - name: Tag, Cargo.toml and metainfo must agree
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          CARGO=$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml \
+                  | sed -n 's/^version *= *"\(.*\)"/\1/p' | head -n1)
+          META=$(sed -n 's/.*<release version="\([^"]*\)".*/\1/p' \
+                  applet/data/io.github.cosmic-ext-applet-app-switcher.metainfo.xml | head -n1)
+
+          echo "tag=$TAG  cargo=$CARGO  metainfo=$META"
+          if [ "$TAG" != "$CARGO" ] || [ "$TAG" != "$META" ]; then
+            echo "::error::version mismatch — tag '$TAG', Cargo.toml '$CARGO', metainfo '$META'"
+            echo "Bump [workspace.package] version and add a matching <release> entry, then re-tag."
+            exit 1
+          fi
+
   build-x86_64:
     name: Build x86_64
+    needs: check-version
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +75,7 @@ jobs:
 
   build-aarch64:
     name: Build aarch64
+    needs: check-version
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-app-switcher"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-ext-applet-app-switcher"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "libcosmic",
  "switcher-config",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "switcher-config"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,15 @@
 members = [".", "applet", "config"]
 resolver = "2"
 
+# Single source of truth for the release version. Bump this together with the newest
+# <release> entry in applet/data/…metainfo.xml — the store shows the metainfo version,
+# and .github/workflows/release.yml fails the release if the two disagree with the tag.
+[workspace.package]
+version = "0.1.5"
+
 [package]
 name = "cosmic-ext-app-switcher"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ make install
 
 Changes take effect immediately — no logout required.
 
+> **Not available as a Flatpak.** cosmic-comp only offers `zcosmic_toplevel_info_v1` and
+> `zwlr_layer_shell_v1` to clients without a Wayland security context, and Flatpak always
+> attaches one — so a sandboxed build can neither list your windows nor draw the overlay,
+> and Super+Tab silently does nothing. Install with the script above instead. See
+> [#10](https://github.com/j0rdiun/cosmic-ext-app-switcher/issues/10) for the measurements.
+
 ---
 
 ## Uninstall

--- a/applet/Cargo.toml
+++ b/applet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmic-ext-applet-app-switcher"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [[bin]]

--- a/applet/data/io.github.cosmic-ext-applet-app-switcher.metainfo.xml
+++ b/applet/data/io.github.cosmic-ext-applet-app-switcher.metainfo.xml
@@ -4,7 +4,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <project_group>COSMIC</project_group>
-  <developer_name>j0rdiun</developer_name>
+  <developer id="io.github.j0rdiun">
+    <name>j0rdiun</name>
+  </developer>
   <name>App Switcher</name>
   <summary>macOS-style Super+Tab app switcher for COSMIC</summary>
   <url type="homepage">https://github.com/j0rdiun/cosmic-ext-app-switcher</url>
@@ -39,6 +41,20 @@
     </screenshot>
   </screenshots>
   <releases>
+    <!-- The newest entry here is the version the COSMIC Store displays. Keep it in sync
+         with [workspace.package] version in Cargo.toml and the git tag; the release
+         workflow refuses to publish when they disagree. -->
+    <release version="0.1.5" date="2026-08-13">
+      <description>
+        <p>Fixes the one-line installer, which downloaded a malformed URL and failed for everyone.</p>
+        <p>Enabling or disabling the Super+Tab shortcut now rewrites COSMIC's shortcut config safely, instead of leaving a file COSMIC can't parse.</p>
+      </description>
+    </release>
+    <release version="0.1.4" date="2026-07-14">
+      <description>
+        <p>Adds a switch scope setting: cycle windows from all workspaces, or only those on the current monitor.</p>
+      </description>
+    </release>
     <release version="0.1.3" date="2026-07-03">
       <description>
         <p>Initial release — Super+Tab overlay switcher with Dark, Light, Frosted, and Midnight themes.</p>

--- a/applet/src/app.rs
+++ b/applet/src/app.rs
@@ -99,6 +99,50 @@ fn switcher_exec() -> String {
     }
 }
 
+/// Rebuild the `system_actions` RON map: every entry except our two keys, wrapped in a
+/// fresh pair of braces, with our entries appended when `cmd` is `Some`.
+///
+/// Rebuilding rather than splicing is what keeps degenerate inputs safe — an empty file
+/// or a single-line `{}` used to produce a body with no opening brace. That doesn't fail
+/// loudly: cosmic-settings-daemon logs a parse error and falls back to the packaged
+/// defaults, so the user's other overrides quietly stop working (issue #10). Mirrors
+/// scripts/shortcut-config.sh.
+fn rebuild_shortcut_map(existing: Option<&str>, cmd: Option<&str>) -> String {
+    let mut out = String::from("{\n");
+
+    for line in existing.unwrap_or_default().lines() {
+        let t = line.trim();
+        if t.is_empty() || t == "{" || t == "}" || t == "{}" {
+            continue;
+        }
+        if t.starts_with("WindowSwitcher:") || t.starts_with("WindowSwitcherPrevious:") {
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    if let Some(cmd) = cmd {
+        out.push_str(&format!("    WindowSwitcher: \"{cmd}\",\n"));
+        out.push_str(&format!("    WindowSwitcherPrevious: \"{cmd} --reverse\",\n"));
+    }
+
+    out.push('}');
+    out.push('\n');
+    out
+}
+
+fn write_shortcut_map(path: &std::path::Path, content: String) -> Result<(), String> {
+    if !content.starts_with('{') || !content.trim_end().ends_with('}') {
+        return Err("refusing to write malformed shortcut config".to_string());
+    }
+    std::fs::write(path, content).map_err(|e| e.to_string())?;
+    // cosmic-config writes these 0600; keep that when we create the file ourselves.
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    Ok(())
+}
+
 fn do_unregister_shortcut() -> Result<(), String> {
     let path = match shortcuts_config_path() {
         Some(p) => p,
@@ -108,52 +152,23 @@ fn do_unregister_shortcut() -> Result<(), String> {
         return Ok(());
     }
     let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
-    let filtered: String = content
-        .lines()
-        .filter(|l| {
-            let t = l.trim();
-            !t.starts_with("WindowSwitcher:") && !t.starts_with("WindowSwitcherPrevious:")
-        })
-        .flat_map(|l| [l, "\n"])
-        .collect();
-    std::fs::write(&path, filtered).map_err(|e| e.to_string())
+    write_shortcut_map(&path, rebuild_shortcut_map(Some(&content), None))
 }
 
 fn do_register_shortcut() -> Result<(), String> {
     let path = shortcuts_config_path()
         .ok_or_else(|| "COSMIC shortcuts directory not found — is COSMIC installed?".to_string())?;
 
-    let cmd = switcher_exec();
+    let existing = std::fs::read_to_string(&path).ok();
+    if existing.as_deref().is_some_and(|s| s.contains("cosmic-ext-app-switcher")) {
+        return Ok(());
+    }
 
     std::fs::create_dir_all(path.parent().unwrap())
         .map_err(|e| e.to_string())?;
 
-    let content = if let Ok(existing) = std::fs::read_to_string(&path) {
-        if existing.contains("cosmic-ext-app-switcher") {
-            return Ok(());
-        }
-        // Strip any existing WindowSwitcher bindings before adding ours —
-        // appending without removing would create duplicate RON keys.
-        let cleaned: String = existing
-            .lines()
-            .filter(|l| {
-                let t = l.trim();
-                !t.starts_with("WindowSwitcher:") && !t.starts_with("WindowSwitcherPrevious:")
-            })
-            .flat_map(|l| [l, "\n"])
-            .collect();
-        let last_brace = cleaned.rfind('}').unwrap_or(cleaned.len());
-        let before = cleaned[..last_brace].trim_end();
-        format!(
-            "{before}\n    WindowSwitcher: \"{cmd}\",\n    WindowSwitcherPrevious: \"{cmd} --reverse\",\n}}\n"
-        )
-    } else {
-        format!(
-            "{{\n    WindowSwitcher: \"{cmd}\",\n    WindowSwitcherPrevious: \"{cmd} --reverse\",\n}}\n"
-        )
-    };
-
-    std::fs::write(&path, content).map_err(|e| e.to_string())
+    let cmd = switcher_exec();
+    write_shortcut_map(&path, rebuild_shortcut_map(existing.as_deref(), Some(&cmd)))
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +348,15 @@ impl Application for AppletApp {
             })
             .collect();
 
+        let flatpak_note: Option<Element<Message>> = std::env::var("FLATPAK_ID").ok().map(|_| {
+            // Nothing of ours runs at `flatpak uninstall`, so a shortcut left registered
+            // keeps Super+Tab pointing at a command that no longer exists — and COSMIC
+            // does not fall back to its built-in switcher (issue #10).
+            text("Flatpak: turn this off before uninstalling, or Super+Tab stays bound to a removed app.")
+                .size(10)
+                .into()
+        });
+
         let shortcut_row = row![
             text("Super+Tab shortcut").size(14),
             cosmic::widget::Space::new().width(Length::Fill),
@@ -341,14 +365,22 @@ impl Application for AppletApp {
         ]
         .align_y(Alignment::Center);
 
+        let mut shortcut_section = column![shortcut_row].spacing(6);
+        if let Some(note) = flatpak_note {
+            shortcut_section = shortcut_section.push(note);
+        }
+
         let mut content = column![
-            shortcut_row,
+            shortcut_section,
             cosmic::widget::divider::horizontal::default(),
             text("Theme").size(14),
             row(swatches).spacing(12),
             cosmic::widget::divider::horizontal::default(),
             text("Switch scope").size(14),
             row(scope_options).spacing(8),
+            // Shown so bug reports can name a version — see the release checklist in
+            // .claude/CLAUDE.md.
+            text(format!("v{}", env!("CARGO_PKG_VERSION"))).size(10),
         ]
         .spacing(12)
         .padding(16)
@@ -361,5 +393,60 @@ impl Application for AppletApp {
         }
 
         self.core.applet.popup_container(content).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rebuild_shortcut_map;
+
+    const CMD: &str = "/home/u/.local/bin/cosmic-ext-app-switcher";
+
+    fn assert_well_formed(s: &str) {
+        assert!(s.starts_with("{\n"), "missing opening brace: {s:?}");
+        assert!(s.ends_with("}\n"), "missing closing brace: {s:?}");
+    }
+
+    /// The inputs that used to yield a body with no opening brace.
+    #[test]
+    fn degenerate_inputs_stay_well_formed() {
+        for existing in [None, Some(""), Some("{}"), Some("{}\n"), Some("{\n}\n"), Some("\n\n")] {
+            let out = rebuild_shortcut_map(existing, Some(CMD));
+            assert_well_formed(&out);
+            assert_eq!(out.matches("WindowSwitcher:").count(), 1, "for {existing:?}");
+        }
+    }
+
+    #[test]
+    fn other_entries_are_preserved() {
+        let existing = "{\n    Terminal: \"ghostty\",\n    WebBrowser: \"firefox\",\n}\n";
+        let out = rebuild_shortcut_map(Some(existing), Some(CMD));
+        assert_well_formed(&out);
+        assert!(out.contains("Terminal: \"ghostty\""));
+        assert!(out.contains("WebBrowser: \"firefox\""));
+        assert!(out.contains(&format!("WindowSwitcher: \"{CMD}\"")));
+        assert!(out.contains(&format!("WindowSwitcherPrevious: \"{CMD} --reverse\"")));
+    }
+
+    #[test]
+    fn existing_bindings_are_replaced_not_duplicated() {
+        let existing = "{\n    WindowSwitcher: \"/old\",\n    WindowSwitcherPrevious: \"/old --reverse\",\n}\n";
+        let out = rebuild_shortcut_map(Some(existing), Some(CMD));
+        assert_eq!(out.matches("WindowSwitcher:").count(), 1);
+        assert_eq!(out.matches("WindowSwitcherPrevious:").count(), 1);
+        assert!(!out.contains("/old"));
+    }
+
+    #[test]
+    fn unregister_leaves_a_valid_map() {
+        let existing = "{\n    Terminal: \"ghostty\",\n    WindowSwitcher: \"x\",\n    WindowSwitcherPrevious: \"x --reverse\",\n}\n";
+        let out = rebuild_shortcut_map(Some(existing), None);
+        assert_well_formed(&out);
+        assert!(!out.contains("WindowSwitcher"));
+        assert!(out.contains("Terminal: \"ghostty\""));
+
+        // …and an empty map when we were the only entry.
+        let only_ours = "{\n    WindowSwitcher: \"x\",\n}\n";
+        assert_eq!(rebuild_shortcut_map(Some(only_ours), None), "{\n}\n");
     }
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "switcher-config"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/install.sh
+++ b/install.sh
@@ -28,9 +28,12 @@ case "$ARCH" in
 esac
 
 # ── Check for COSMIC ─────────────────────────────────────────────────────────
+# The shortcuts directory itself may not exist yet on a fresh install that has never
+# customised a keybinding, so presence of COSMIC is checked more loosely — the shortcut
+# step below creates the config when it's missing.
 SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts"
-if [ ! -d "$SHORTCUTS_DIR" ]; then
-    echo "Error: COSMIC desktop shortcuts directory not found." >&2
+if ! command -v cosmic-comp &>/dev/null && [ ! -d "$HOME/.config/cosmic" ]; then
+    echo "Error: COSMIC desktop not detected." >&2
     echo "Make sure COSMIC desktop is installed and has been launched at least once." >&2
     exit 1
 fi
@@ -59,17 +62,23 @@ else
     exit 1
 fi
 
-get_url() {
-    echo "$RELEASE_JSON" | grep "browser_download_url" | grep "$1" | grep "$ARCH_TAG" | cut -d '"' -f 4
+# Match on the asset *filename* only. Matching anywhere in the line would also hit the
+# repository name inside every asset URL ("…/cosmic-ext-app-switcher/releases/download/…"),
+# which returned two URLs for the switcher and made curl fail with
+# "URL rejected: Malformed input to a URL function".
+get_url() {                                     # $1 = exact asset filename
+    echo "$RELEASE_JSON" \
+        | grep -o '"browser_download_url": *"[^"]*"' \
+        | cut -d '"' -f 4 \
+        | awk -v want="/$1" 'substr($0, length($0) - length(want) + 1) == want' \
+        | head -n1
 }
 
-get_asset_url() {
-    echo "$RELEASE_JSON" | grep "browser_download_url" | grep "$1" | cut -d '"' -f 4
-}
-
-SWITCHER_URL=$(get_url "$BINARY")
-APPLET_URL=$(get_url "$APPLET")
-SVG_URL=$(get_asset_url "$SVG_NAME")
+# `|| true` keeps a no-match (empty) result from aborting the script under `set -e`,
+# so the explicit empty checks below stay reachable.
+SWITCHER_URL=$(get_url "$BINARY-$ARCH_TAG" || true)
+APPLET_URL=$(get_url "$APPLET-$ARCH_TAG" || true)
+SVG_URL=$(get_url "$SVG_NAME" || true)
 
 if [ -z "$SWITCHER_URL" ]; then
     echo "Error: could not find switcher binary for $ARCH_TAG." >&2
@@ -140,20 +149,48 @@ fi
 if [ -f "$SCRIPT_DIR/scripts/enable.sh" ]; then
     bash "$SCRIPT_DIR/scripts/enable.sh"
 else
-    CONFIG=$(find "$SHORTCUTS_DIR" -name "system_actions" 2>/dev/null | sort -V | tail -1)
+    # Standalone (curl | bash) path — mirrors scripts/find-config.sh and
+    # scripts/shortcut-config.sh, which aren't on disk here.
+    CONFIG=$(find "$SHORTCUTS_DIR" -name "system_actions" 2>/dev/null | sort -V | tail -1 || true)
     if [ -z "$CONFIG" ]; then
-        echo "Warning: could not find COSMIC system_actions config — shortcut not registered." >&2
-        echo "Run 'make enable' from the project directory to register manually." >&2
-        exit 0
+        # Never customised shortcuts before: create the config in the newest schema dir.
+        VERSION_DIR=$(find "$SHORTCUTS_DIR" -maxdepth 1 -type d -name 'v[0-9]*' 2>/dev/null | sort -V | tail -1 || true)
+        CONFIG="${VERSION_DIR:-$SHORTCUTS_DIR/v1}/system_actions"
     fi
-    if grep -q "cosmic-ext-app-switcher" "$CONFIG"; then
+
+    if [ -f "$CONFIG" ] && grep -q "cosmic-ext-app-switcher" "$CONFIG"; then
         echo "Shortcut already registered."
     else
+        # Rebuild the RON map rather than patching it: a file left without its braces
+        # fails to parse, and cosmic-settings-daemon then silently falls back to the
+        # packaged defaults, dropping the user's other overrides (issue #10).
+        BODY=""
+        if [ -s "$CONFIG" ]; then
+            BODY=$(awk '
+                /^[[:space:]]*\{?[[:space:]]*\}?[[:space:]]*$/          { next }
+                /^[[:space:]]*(WindowSwitcher|WindowSwitcherPrevious):/ { next }
+                { print }
+            ' "$CONFIG")
+        fi
+
         TMPCONF=$(mktemp)
-        grep -vE "^\s*(WindowSwitcher|WindowSwitcherPrevious):" "$CONFIG" | head -n -1 > "$TMPCONF"
-        printf '    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' \
-            "$INSTALL_DIR/$BINARY" "$INSTALL_DIR/$BINARY" >> "$TMPCONF"
+        {
+            printf '{\n'
+            if [ -n "$BODY" ]; then printf '%s\n' "$BODY"; fi
+            printf '    WindowSwitcher: "%s",\n' "$INSTALL_DIR/$BINARY"
+            printf '    WindowSwitcherPrevious: "%s --reverse",\n' "$INSTALL_DIR/$BINARY"
+            printf '}\n'
+        } > "$TMPCONF"
+
+        if ! head -n1 "$TMPCONF" | grep -q '^{' || ! tail -n1 "$TMPCONF" | grep -q '^}'; then
+            rm -f "$TMPCONF"
+            echo "Error: refusing to write malformed shortcut config to $CONFIG" >&2
+            exit 1
+        fi
+
+        mkdir -p "$(dirname "$CONFIG")"
         mv "$TMPCONF" "$CONFIG"
+        chmod 600 "$CONFIG"
         echo "Shortcut registered."
     fi
 fi

--- a/io.github.cosmic-ext-applet-app-switcher.json
+++ b/io.github.cosmic-ext-applet-app-switcher.json
@@ -6,9 +6,9 @@
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
   "command": "cosmic-ext-applet-app-switcher",
   "finish-args": [
+    "--share=ipc",
     "--socket=wayland",
     "--device=dri",
-    "--share=ipc",
     "--filesystem=xdg-config/cosmic:rw",
     "--filesystem=xdg-data/applications:ro",
     "--filesystem=xdg-data/icons:ro",

--- a/scripts/disable.sh
+++ b/scripts/disable.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/shortcut-config.sh
+. "$SCRIPT_DIR/shortcut-config.sh"
+
 set +e
 CONFIG=$("$SCRIPT_DIR/find-config.sh")
 rc=$?
@@ -25,8 +28,8 @@ if ! grep -qE "^\s*(WindowSwitcher|WindowSwitcherPrevious):" "$CONFIG"; then
     exit 0
 fi
 
-TMPFILE=$(mktemp)
-grep -vE "^\s*(WindowSwitcher|WindowSwitcherPrevious):" "$CONFIG" > "$TMPFILE"
-mv "$TMPFILE" "$CONFIG"
+# Rewrites the map without our entries, leaving a valid (possibly empty) RON map so
+# cosmic-comp keeps parsing the file and restores its built-in switcher.
+shortcut_unregister "$CONFIG"
 
 echo "Disabled. COSMIC default switcher restored."

--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 BINARY="$HOME/.local/bin/cosmic-ext-app-switcher"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/shortcut-config.sh
+. "$SCRIPT_DIR/shortcut-config.sh"
+
 set +e
 CONFIG=$("$SCRIPT_DIR/find-config.sh")
 rc=$?
@@ -12,12 +15,12 @@ set -e
 case "$rc" in
     0) ;;
     2)
+        # No config yet — find-config.sh printed the canonical creation path.
         if [ ! -f "$BINARY" ]; then
             echo "Error: binary not found at $BINARY — run 'make install' first to deploy the binary." >&2
             exit 1
         fi
-        mkdir -p "$(dirname "$CONFIG")"
-        printf '{\n    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' "$BINARY" "$BINARY" > "$CONFIG"
+        shortcut_register "$CONFIG" "$BINARY"
         echo "Created $CONFIG and enabled. cosmic-comp will reload shortcuts automatically."
         exit 0
         ;;
@@ -35,12 +38,7 @@ if [ ! -f "$BINARY" ]; then
     echo "Warning: binary not found at $BINARY — run 'make install' first to deploy the binary."
 fi
 
-TMPFILE=$(mktemp)
-# Strip any existing WindowSwitcher bindings (avoids duplicate RON keys if another
-# switcher was registered), remove the closing brace, then append our entries.
-grep -vE "^\s*(WindowSwitcher|WindowSwitcherPrevious):" "$CONFIG" | head -n -1 > "$TMPFILE"
-printf '    WindowSwitcher: "%s",\n    WindowSwitcherPrevious: "%s --reverse",\n}\n' \
-    "$BINARY" "$BINARY" >> "$TMPFILE"
-mv "$TMPFILE" "$CONFIG"
+# Rebuilds the map with our entries, keeping every other key (see shortcut-config.sh).
+shortcut_register "$CONFIG" "$BINARY"
 
 echo "Enabled. cosmic-comp will reload shortcuts automatically."

--- a/scripts/shortcut-config.sh
+++ b/scripts/shortcut-config.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Safe edits to COSMIC's system_actions RON map, shared by enable.sh and disable.sh.
+#
+# A malformed system_actions doesn't fail loudly: cosmic-settings-daemon logs a parse
+# error and falls back to the packaged system defaults, so every *other* override in the
+# file (a custom terminal command, say) silently stops working while our shortcut never
+# registers at all. Both helpers therefore rebuild the map from scratch and refuse to
+# write anything that isn't brace-delimited.
+#
+# Degenerate inputs handled: file missing, file empty, and a single-line "{}" (the earlier
+# `grep -v … | head -n -1` pipeline turned that one into a body with no opening brace).
+
+# Emit every entry line of $1 except our own two keys and the enclosing braces.
+_shortcut_entries() {
+    [ -s "$1" ] || return 0
+    awk '
+        /^[[:space:]]*\{?[[:space:]]*\}?[[:space:]]*$/                { next }
+        /^[[:space:]]*(WindowSwitcher|WindowSwitcherPrevious):/       { next }
+        { print }
+    ' "$1"
+}
+
+# _write_map <config> [extra-line...] — rebuild <config> as a valid RON map.
+_write_map() {
+    local config="$1"; shift
+    local body tmp
+    body=$(_shortcut_entries "$config")
+
+    tmp=$(mktemp)
+    {
+        printf '{\n'
+        if [ -n "$body" ]; then printf '%s\n' "$body"; fi
+        if [ "$#" -gt 0 ]; then printf '%s\n' "$@"; fi
+        printf '}\n'
+    } > "$tmp"
+
+    if ! head -n1 "$tmp" | grep -q '^{' || ! tail -n1 "$tmp" | grep -q '^}'; then
+        rm -f "$tmp"
+        echo "Error: refusing to write malformed shortcut config to $config" >&2
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$config")"
+    mv "$tmp" "$config"
+    chmod 600 "$config"
+}
+
+# shortcut_register <config> <binary>
+shortcut_register() {
+    _write_map "$1" \
+        "    WindowSwitcher: \"$2\"," \
+        "    WindowSwitcherPrevious: \"$2 --reverse\","
+}
+
+# shortcut_unregister <config>
+shortcut_unregister() {
+    _write_map "$1"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ pub fn socket_path() -> std::path::PathBuf {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "cosmic-ext-app-switcher")]
+#[command(name = "cosmic-ext-app-switcher", version)]
 pub struct Args {
     #[arg(long, default_value_t = false)]
     pub reverse: bool,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,26 +14,35 @@ SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts"
 echo "Uninstalling cosmic-ext-app-switcher..."
 
 # ── Remove shortcut registration ──────────────────────────────────────────────
+# Matches on the RON *keys*, not on the binary path: a substring match would also delete
+# an unrelated entry that happens to mention the path, and rebuilding the whole map keeps
+# the braces intact. Dropping the WindowSwitcher keys is what hands Super+Tab back to
+# COSMIC's built-in switcher — a leftover entry pointing at a removed binary just spawns
+# nothing, with no fallback (issue #10).
 CONFIG=$(find "$SHORTCUTS_DIR" -name "system_actions" 2>/dev/null | sort -V | tail -1 || true)
-if [ -n "$CONFIG" ]; then
-    CHANGED=0
-    if grep -q "$BINARY" "$CONFIG" 2>/dev/null; then
-        TMPFILE=$(mktemp)
-        grep -v "$BINARY" "$CONFIG" > "$TMPFILE"
-        mv "$TMPFILE" "$CONFIG"
-        CHANGED=1
+if [ -n "$CONFIG" ] && grep -qE "^\s*(WindowSwitcher|WindowSwitcherPrevious):" "$CONFIG" 2>/dev/null; then
+    BODY=$(awk '
+        /^[[:space:]]*\{?[[:space:]]*\}?[[:space:]]*$/          { next }
+        /^[[:space:]]*(WindowSwitcher|WindowSwitcherPrevious):/ { next }
+        { print }
+    ' "$CONFIG")
+
+    TMPFILE=$(mktemp)
+    {
+        printf '{\n'
+        if [ -n "$BODY" ]; then printf '%s\n' "$BODY"; fi
+        printf '}\n'
+    } > "$TMPFILE"
+
+    if ! head -n1 "$TMPFILE" | grep -q '^{' || ! tail -n1 "$TMPFILE" | grep -q '^}'; then
+        rm -f "$TMPFILE"
+        echo "Error: refusing to write malformed shortcut config to $CONFIG" >&2
+        exit 1
     fi
-    if grep -q "$OLD_BINARY" "$CONFIG" 2>/dev/null; then
-        TMPFILE=$(mktemp)
-        grep -v "$OLD_BINARY" "$CONFIG" > "$TMPFILE"
-        mv "$TMPFILE" "$CONFIG"
-        CHANGED=1
-    fi
-    if [ "$CHANGED" -eq 1 ]; then
-        echo "Shortcut removed. COSMIC default switcher restored."
-    else
-        echo "Shortcut not registered — nothing to remove."
-    fi
+
+    mv "$TMPFILE" "$CONFIG"
+    chmod 600 "$CONFIG"
+    echo "Shortcut removed. COSMIC default switcher restored."
 else
     echo "Shortcut not registered — nothing to remove."
 fi


### PR DESCRIPTION
Triage pass over the five open issues after the COSMIC Store launch. Fixes the two confirmed bugs, straightens out versioning, and documents why the store build can't work.

## #4 — the one-line installer is broken for everyone

Not Fedora-specific. `get_url()` matched `cosmic-ext-app-switcher` anywhere in the release JSON, which also matches the **repository name inside every asset URL**:

```
…/cosmic-ext-app-switcher/releases/download/v0.1.4/cosmic-ext-app-switcher-x86_64-unknown-linux-gnu
…/cosmic-ext-app-switcher/releases/download/v0.1.4/cosmic-ext-applet-app-switcher-x86_64-unknown-linux-gnu
```

Two URLs came back, `curl -o` got both as one argument, and failed with `curl: (3) URL rejected: Malformed input to a URL function` — exactly the error in the issue's screenshot. Reproduced against the live API; matching is now anchored to the asset filename.

Also: the installer used to abort on a system that had never customised a keybinding (`~/.config/cosmic/com.system76.CosmicSettings.Shortcuts` absent). It now creates `system_actions` itself.

## #10 — shortcut config could be left unparseable

Registration stripped the closing brace and appended, which drops the *opening* brace when the existing file is empty or a single-line `{}`. That fails quietly: cosmic-settings-daemon logs a parse error and falls back to packaged defaults, so the user's other overrides stop working. All four writers now rebuild the whole map and refuse to write anything not brace-delimited; `uninstall.sh` matches on RON keys instead of the binary path.

## Versioning

`Cargo.toml` said 0.1.0, the metainfo said 0.1.3, the tag said v0.1.4 — and the metainfo is what the store displays. Version now lives once in `[workspace.package]`; `release.yml` refuses to publish when tag, crate version and newest `<release>` disagree. `--version` works, and the applet popup shows its version.

## The Flatpak build cannot work

cosmic-comp gates `zcosmic_toplevel_info_v1` and `zwlr_layer_shell_v1` on `client_not_sandboxed`, and Flatpak always attaches a Wayland security context. Measured on cosmic-comp `7ee78d9` by dumping `wl_registry` inside and outside the sandbox:

| | globals |
|---|---|
| host | 58 |
| sandbox | 36 |

The 22 missing include toplevel-info, toplevel-manager and layer-shell — no window list, no overlay. Documented in README and CLAUDE.md; de-listing is being raised with pop-os separately.

## Verification

- 4 new unit tests over the degenerate map inputs; `cargo test` green
- 63 fixture assertions over enable/disable/uninstall against empty, `{}`, `{\n}\n`, populated and already-registered configs
- full `curl | bash` install simulated into a throwaway HOME: both binaries download, shortcut registers, uninstall leaves a valid map
- `appstreamcli validate` clean; `make install` on a live COSMIC session leaves `system_actions` byte-identical

Written with assistance from Claude Code.