### PR TITLE
fix: register the shortcut on a COSMIC that has no shortcuts dir yet

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,14 @@ BINARY="cosmic-ext-app-switcher"
 APPLET="cosmic-ext-applet-app-switcher"
 APPLET_DESKTOP_ID="io.github.cosmic-ext-applet-app-switcher"
 SVG_NAME="io.github.cosmic-ext-applet-app-switcher-symbolic.svg"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)" || SCRIPT_DIR=""
+# Piped (curl | bash) means there is no script file, and `dirname ""` would resolve to the
+# current directory — letting whatever the user happens to have cd'd into masquerade as a
+# checkout of this repo and supply its scripts/. Only trust a real script path.
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR=""
+fi
 
 # ── Detect architecture ───────────────────────────────────────────────────────
 ARCH=$(uname -m)

--- a/scripts/find-config.sh
+++ b/scripts/find-config.sh
@@ -4,10 +4,17 @@
 
 SHORTCUTS_DIR="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts"
 
+# The shortcuts directory is only created once something writes a shortcut, so its absence
+# means "nothing customised yet", not "COSMIC missing" — that's the exit-2 case. Only a
+# system with no sign of COSMIC at all is exit 1.
 if [ ! -d "$SHORTCUTS_DIR" ]; then
-    echo "Error: COSMIC shortcuts directory not found: $SHORTCUTS_DIR" >&2
-    echo "Is COSMIC desktop installed and has it been opened at least once?" >&2
-    exit 1
+    if ! command -v cosmic-comp >/dev/null 2>&1 && [ ! -d "$HOME/.config/cosmic" ]; then
+        echo "Error: COSMIC desktop not detected." >&2
+        echo "Is COSMIC desktop installed and has it been opened at least once?" >&2
+        exit 1
+    fi
+    echo "$SHORTCUTS_DIR/v1/system_actions"
+    exit 2
 fi
 
 CONFIG=$(find "$SHORTCUTS_DIR" -name "system_actions" 2>/dev/null | sort -V | tail -1)


### PR DESCRIPTION
Found while verifying the v0.1.5 installer end to end against the published release — the download half of #4 is fixed, but a fresh COSMIC still couldn't get its shortcut registered.

**`find-config.sh` treated a missing shortcuts directory as "COSMIC not installed"** and exited 1. That directory only appears once something writes a shortcut, so on a machine that has never customised a keybinding, `make enable` — and any `install.sh` run that reached `scripts/enable.sh` — failed with:

```
Error: COSMIC shortcuts directory not found: …/com.system76.CosmicSettings.Shortcuts
```

#11 relaxed this check in `install.sh` itself but not in `find-config.sh`, so the fresh-install case was only half fixed. A missing directory is now the existing exit-2 "not created yet" path; only a system with no sign of COSMIC at all is exit 1.

**`install.sh` also trusted `$PWD` as its checkout when piped.** `BASH_SOURCE[0]` is unset under `curl | bash`, so `dirname ""` resolved to the current directory — meaning a piped install run from inside any directory that happens to contain `scripts/enable.sh` would execute that unrelated script. A piped run now has no `SCRIPT_DIR` and always takes the self-contained path.

## Verification

- `make enable` on a fresh COSMIC (no shortcuts dir): creates a well-formed config
- `status.sh` on the same: reports the config instead of an error
- `find-config.sh` with no COSMIC present: still exits 1
- `curl | bash` with cwd inside a checkout, fresh COSMIC: registers correctly
- 63 fixture assertions and 4 unit tests still green

Written with assistance from Claude Code.