### PR TITLE
docs: warn that the COSMIC Store listing is live, broken, and stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,34 @@ make install
 
 Changes take effect immediately — no logout required.
 
-> **Not available as a Flatpak.** cosmic-comp only offers `zcosmic_toplevel_info_v1` and
-> `zwlr_layer_shell_v1` to clients without a Wayland security context, and Flatpak always
-> attaches one — so a sandboxed build can neither list your windows nor draw the overlay,
-> and Super+Tab silently does nothing. Install with the script above instead. See
-> [#10](https://github.com/j0rdiun/cosmic-ext-app-switcher/issues/10) for the measurements.
+> ### Do not install this from the COSMIC Store
+>
+> The store listing is broken and cannot be made to work. cosmic-comp only offers
+> `zcosmic_toplevel_info_v1`, `zcosmic_toplevel_manager_v1` and `zwlr_layer_shell_v1` to
+> clients without a Wayland security context, and Flatpak always attaches one, so a
+> sandboxed build can neither list your windows nor draw the overlay. Super+Tab silently
+> does nothing. Measurements are in
+> [#10](https://github.com/j0rdiun/cosmic-ext-app-switcher/issues/10); System76 confirmed
+> there is no path for it today in
+> [cosmic-comp#2734](https://github.com/pop-os/cosmic-comp/issues/2734), and are planning
+> configurable `cosmic-session` components to allow it in future.
+>
+> Removal of the listing is requested in
+> [cosmic-flatpak#259](https://github.com/pop-os/cosmic-flatpak/issues/259). Until that
+> lands it is still installable, and still serves 0.1.3. **Use the install script above
+> instead.**
+>
+> If you already installed it from the store, uninstalling leaves Super+Tab dead, because
+> the shortcut it registered outlives the app and COSMIC does not fall back to its built-in
+> switcher. To clean up:
+>
+> ```bash
+> flatpak uninstall io.github.cosmic-ext-applet-app-switcher
+> curl -fsSL https://raw.githubusercontent.com/j0rdiun/cosmic-ext-app-switcher/main/uninstall.sh | bash
+> ```
+>
+> The second command rewrites COSMIC's shortcut config and restores the default switcher.
+> It is safe to run whether or not the native version is installed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Changes take effect immediately — no logout required.
 > does nothing. Measurements are in
 > [#10](https://github.com/j0rdiun/cosmic-ext-app-switcher/issues/10); System76 confirmed
 > there is no path for it today in
-> [cosmic-comp#2734](https://github.com/pop-os/cosmic-comp/issues/2734), and are planning
+> [cosmic-comp#2734](https://github.com/pop-os/cosmic-comp/issues/2734#issuecomment-5293857795), and are planning
 > configurable `cosmic-session` components to allow it in future.
 >
 > Removal of the listing is requested in


### PR DESCRIPTION
The old note said the app was "not available as a Flatpak". That is not what a user hitting this actually sees. The COSMIC Store listing is still up, still installable, and still serving 0.1.3 (pinned commit `8f62e4d`, which predates both v0.1.4 and v0.1.5). #10 and #13 both walked into it.

Changes:

- Say plainly not to install it from the store, and why: cosmic-comp gates `zcosmic_toplevel_info_v1`, `zcosmic_toplevel_manager_v1` and `zwlr_layer_shell_v1` on `client_not_sandboxed`, false for any client with a Wayland security context.
- Record that System76 confirmed there is no path for this today in pop-os/cosmic-comp#2734, while planning configurable `cosmic-session` components to allow it later.
- Link the removal request pop-os/cosmic-flatpak#259 and the PR that unblocks it, pop-os/cosmic-flatpak#268. Deleting the manifest alone would not have de-listed anything: their tooling never removes the ostree ref, so the app stays installable. Two apps removed there in May are still installable today.
- Add recovery steps for people who already installed it.

The recovery steps matter because uninstalling the Flatpak leaves behind the `WindowSwitcher` entry it registered in COSMIC's shortcut config, and COSMIC does not fall back to its built-in switcher when the command it is told to run is missing, so Super+Tab stays dead.

Verified `uninstall.sh` handles that case, in a throwaway `$HOME` with a shortcut pointing at `flatpak run ...` and no native binary installed:

```
=== BEFORE ===
{
    WindowSwitcher: "flatpak run io.github.cosmic-ext-applet-app-switcher",
    WindowSwitcherPrevious: "flatpak run io.github.cosmic-ext-applet-app-switcher --reverse",
    Screenshot: "cosmic-screenshot",
}

  Shortcut removed. COSMIC default switcher restored.
  Binary not found — nothing to remove.
  Uninstall complete.

=== AFTER ===
{
    Screenshot: "cosmic-screenshot",
}
```

It matches on the RON keys rather than the binary path, so it clears a Flatpak-registered entry, preserves unrelated shortcuts, and exits clean with nothing native installed.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
